### PR TITLE
Add Token PDA

### DIFF
--- a/tokens/smartbch.json
+++ b/tokens/smartbch.json
@@ -590,5 +590,13 @@
     "decimals": 18,
     "chainId": 10000,
     "logoURI": "https://assets.mistswap.fi/blockchains/smartbch/assets/0x8dd87b3f50bE9C6Ac5EC08458803843F0D294B3d/logo.png"
+  },
+  {
+    "name": "PandaToken",
+    "address": "0x288B6Ca2eFCF39C9B68052B0088A0cB3f3D3B5f2",
+    "symbol": "PDA",
+    "decimals": 18,
+    "chainId": 10000,
+    "logoURI": "https://assets.mistswap.fi/blockchains/smartbch/assets/0x288B6Ca2eFCF39C9B68052B0088A0cB3f3D3B5f2/logo.png"
   }
 ]


### PR DESCRIPTION
PDA token has been added to Mistswap with more than 110K liquidity, please help to add to default token list, thank you.